### PR TITLE
Fix horizon not working & require beta 12 or later

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -52,6 +52,7 @@ return [
         ->get('/horizon/api/jobs/failed', 'horizon.failed-jobs.index', Api\FailedJobs::class)
         ->get('/horizon/api/jobs/failed/{id}', 'horizon.failed-jobs.show', Api\FailedJob::class)
         ->post('/horizon/api/jobs/retry/{id}', 'horizon.retry-jobs.show', Api\RetryJob::class)
+        ->get('/horizon', 'horizon.index', Http\Home::class)
         ->get('/horizon/{view:.*}', 'horizon.index', Http\Home::class),
     // Assets
     new Extend\PublishAssets(

--- a/extend.php
+++ b/extend.php
@@ -49,6 +49,7 @@ return [
         ->get('/horizon/api/metrics/queues', 'horizon.queues-metrics.index', Api\QueueMetrics::class)
         ->get('/horizon/api/metrics/queues/{id}', 'horizon.queues-metrics.show', Api\QueueJobMetrics::class)
         ->get('/horizon/api/jobs/recent', 'horizon.recent-jobs.index', Api\RecentJobs::class)
+        ->get('/horizon/api/jobs/recent/{id}', 'horizon.recent-jobs.show', Api\RecentJob::class)
         ->get('/horizon/api/jobs/failed', 'horizon.failed-jobs.index', Api\FailedJobs::class)
         ->get('/horizon/api/jobs/failed/{id}', 'horizon.failed-jobs.show', Api\FailedJob::class)
         ->post('/horizon/api/jobs/retry/{id}', 'horizon.retry-jobs.show', Api\RetryJob::class)

--- a/src/Api/FailedJob.php
+++ b/src/Api/FailedJob.php
@@ -7,7 +7,7 @@ use Laravel\Horizon\Contracts\JobRepository;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\Response\JsonResponse;
+use Laminas\Diactoros\Response\JsonResponse;
 
 class FailedJob implements RequestHandlerInterface
 {

--- a/src/Api/FailedJobs.php
+++ b/src/Api/FailedJobs.php
@@ -8,7 +8,7 @@ use Laravel\Horizon\Contracts\TagRepository;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\Response\JsonResponse;
+use Laminas\Diactoros\Response\JsonResponse;
 
 class FailedJobs implements RequestHandlerInterface
 {

--- a/src/Api/JobMetrics.php
+++ b/src/Api/JobMetrics.php
@@ -6,7 +6,7 @@ use Laravel\Horizon\Contracts\MetricsRepository;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\Response\JsonResponse;
+use Laminas\Diactoros\Response\JsonResponse;
 
 class JobMetrics implements RequestHandlerInterface
 {

--- a/src/Api/Masters.php
+++ b/src/Api/Masters.php
@@ -8,7 +8,7 @@ use Laravel\Horizon\Contracts\WorkloadRepository;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\Response\JsonResponse;
+use Laminas\Diactoros\Response\JsonResponse;
 
 class Masters implements RequestHandlerInterface
 {

--- a/src/Api/Metrics.php
+++ b/src/Api/Metrics.php
@@ -6,7 +6,7 @@ use Laravel\Horizon\Contracts\MetricsRepository;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\Response\JsonResponse;
+use Laminas\Diactoros\Response\JsonResponse;
 
 class Metrics implements RequestHandlerInterface
 {

--- a/src/Api/MonitorTag.php
+++ b/src/Api/MonitorTag.php
@@ -8,7 +8,7 @@ use Laravel\Horizon\RedisQueue;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\Response\EmptyResponse;
+use Laminas\Diactoros\Response\EmptyResponse;
 
 class MonitorTag implements RequestHandlerInterface
 {

--- a/src/Api/Monitoring.php
+++ b/src/Api/Monitoring.php
@@ -6,7 +6,7 @@ use Laravel\Horizon\Contracts\TagRepository;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\Response\JsonResponse;
+use Laminas\Diactoros\Response\JsonResponse;
 
 class Monitoring implements RequestHandlerInterface
 {

--- a/src/Api/QueueJobMetrics.php
+++ b/src/Api/QueueJobMetrics.php
@@ -6,7 +6,7 @@ use Laravel\Horizon\Contracts\MetricsRepository;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\Response\JsonResponse;
+use Laminas\Diactoros\Response\JsonResponse;
 
 class QueueJobMetrics implements RequestHandlerInterface
 {

--- a/src/Api/QueueMetrics.php
+++ b/src/Api/QueueMetrics.php
@@ -6,7 +6,7 @@ use Laravel\Horizon\Contracts\MetricsRepository;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\Response\JsonResponse;
+use Laminas\Diactoros\Response\JsonResponse;
 
 class QueueMetrics implements RequestHandlerInterface
 {

--- a/src/Api/RecentJob.php
+++ b/src/Api/RecentJob.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Bokt\Horizon\Api;
+
+use Laravel\Horizon\Contracts\JobRepository;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Laminas\Diactoros\Response\JsonResponse;
+
+class RecentJob implements RequestHandlerInterface
+{
+    /**
+     * @var JobRepository
+     */
+    private $jobs;
+
+    public function __construct(JobRepository $jobs)
+    {
+        $this->jobs = $jobs;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $job = (array) $this->jobs->getJobs([$request->getQueryParams()['id']])->map(function ($job) {
+            $job->payload = json_decode($job->payload);
+
+            return $job;
+        })->first();
+
+        return new JsonResponse($job);
+    }
+}

--- a/src/Api/RecentJobs.php
+++ b/src/Api/RecentJobs.php
@@ -6,7 +6,7 @@ use Laravel\Horizon\Contracts\JobRepository;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\Response\JsonResponse;
+use Laminas\Diactoros\Response\JsonResponse;
 
 class RecentJobs implements RequestHandlerInterface
 {

--- a/src/Api/RetryJob.php
+++ b/src/Api/RetryJob.php
@@ -8,7 +8,7 @@ use Laravel\Horizon\RedisQueue;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\Response\EmptyResponse;
+use Laminas\Diactoros\Response\EmptyResponse;
 
 class RetryJob implements RequestHandlerInterface
 {

--- a/src/Api/Stats.php
+++ b/src/Api/Stats.php
@@ -11,7 +11,7 @@ use Laravel\Horizon\WaitTimeCalculator;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\Response\JsonResponse;
+use Laminas\Diactoros\Response\JsonResponse;
 
 class Stats implements RequestHandlerInterface
 {

--- a/src/Api/StopMonitoringTag.php
+++ b/src/Api/StopMonitoringTag.php
@@ -8,7 +8,7 @@ use Laravel\Horizon\RedisQueue;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\Response\EmptyResponse;
+use Laminas\Diactoros\Response\EmptyResponse;
 
 class StopMonitoringTag implements RequestHandlerInterface
 {

--- a/src/Api/TagMonitoring.php
+++ b/src/Api/TagMonitoring.php
@@ -8,7 +8,7 @@ use Laravel\Horizon\Contracts\TagRepository;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\Response\JsonResponse;
+use Laminas\Diactoros\Response\JsonResponse;
 
 class TagMonitoring implements RequestHandlerInterface
 {

--- a/src/Api/Workload.php
+++ b/src/Api/Workload.php
@@ -6,7 +6,7 @@ use Laravel\Horizon\Contracts\WorkloadRepository;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\Response\JsonResponse;
+use Laminas\Diactoros\Response\JsonResponse;
 
 class Workload implements RequestHandlerInterface
 {

--- a/src/Http/Home.php
+++ b/src/Http/Home.php
@@ -8,7 +8,7 @@ use Laravel\Horizon\Horizon;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\Response\HtmlResponse;
+use Laminas\Diactoros\Response\HtmlResponse;
 
 class Home implements RequestHandlerInterface
 {


### PR DESCRIPTION
- Update Zend namespaces to Laminas
- Add `/admin/horizon` route so it doesn't return 404
  - only `/admin/horizon/` worked
- Add `/admin/horizon/api/jobs/recent/{id}` route
- Make Horizon work
  - Set `app.env`
  - Make `flarum.queue.connection` be instance of Horizon's `RedisQueue`
  - Add `driver` method to anonymous function