### PR TITLE
fix: Publish assets to filesystem disk, instead of local path

### DIFF
--- a/src/Extend/PublishAssets.php
+++ b/src/Extend/PublishAssets.php
@@ -28,7 +28,6 @@ class PublishAssets implements LifecycleInterface, ExtenderInterface
     private $from;
 
     /**
-     *
      * @var Cloud
      */
     private $assetsDisk;
@@ -37,7 +36,7 @@ class PublishAssets implements LifecycleInterface, ExtenderInterface
     {
         $paths = resolve(Paths::class);
         $factory = resolve(Factory::class);
-        
+
         $this->from = $paths->vendor.'/laravel/horizon/public';
         $this->assetsDisk = $factory->disk('flarum-assets');
     }
@@ -45,7 +44,7 @@ class PublishAssets implements LifecycleInterface, ExtenderInterface
     public function onEnable(Container $container, Extension $extension)
     {
         if ($extension->name === 'blomstra/horizon') {
-            
+
             /** @var \Illuminate\Filesystem\Filesystem $localFilesystem */
             $localFilesystem = $container->make('files');
 

--- a/src/Http/Home.php
+++ b/src/Http/Home.php
@@ -64,7 +64,7 @@ class Home implements RequestHandlerInterface
             'cssFile'                      => 'app.css', // TODO: support fof/nightmode
             'horizonScriptVariables'       => Horizon::scriptVariables(),
             'isDownForMaintenance'         => $this->config->inMaintenanceMode(),
-            'assetsUrl'                    => $this->assetsDir->url('/'),
+            'assetsUrl'                    => $this->assetsDir->url(''),
         ])->render());
     }
 }

--- a/src/Http/Home.php
+++ b/src/Http/Home.php
@@ -15,8 +15,8 @@ namespace Blomstra\Horizon\Http;
 use Flarum\Foundation\Config;
 use Flarum\Frontend\Frontend;
 use Flarum\Http\UrlGenerator;
+use Illuminate\Contracts\Filesystem\Cloud;
 use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
-use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Contracts\View\Factory;
 use Laminas\Diactoros\Response\HtmlResponse;
 use Laravel\Horizon\Horizon;
@@ -36,7 +36,7 @@ class Home implements RequestHandlerInterface
     private $frontend;
 
     /**
-     * @var Filesystem
+     * @var Cloud
      */
     private $assetsDir;
 

--- a/src/Providers/HorizonServiceProvider.php
+++ b/src/Providers/HorizonServiceProvider.php
@@ -175,4 +175,8 @@ class HorizonServiceProvider extends Provider
     protected function registerCommands()
     {
     }
+
+    protected function registerResources()
+    {
+    }
 }


### PR DESCRIPTION
To support the assets filesystem being remote, publish the horizon assets to the `disk`, rather than local assets path