### PR TITLE
feat: improved dashboard stats, allow trim config

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -14,6 +14,7 @@ namespace Blomstra\Horizon;
 
 use Blomstra\Redis\Extend\Bindings;
 use Flarum\Extend as Flarum;
+use Flarum\Settings\Event\Saved;
 use Illuminate\Console\Scheduling\Event;
 use Laravel\Horizon\Console as Laravel;
 
@@ -26,6 +27,14 @@ return [
     new Flarum\Locales(__DIR__.'/resources/locale'),
 
     new Bindings(),
+
+    (new Flarum\Settings())
+        ->default('blomstra-horizon.trim.recent', 60)
+        ->default('blomstra-horizon.trim.pending', 60)
+        ->default('blomstra-horizon.trim.completed', 60)
+        ->default('blomstra-horizon.trim.recent_failed', 10080)
+        ->default('blomstra-horizon.trim.failed', 10080)
+        ->default('blomstra-horizon.trim.monitored', 10080),
 
     (new Flarum\ServiceProvider())
         ->register(Providers\HorizonServiceProvider::class),

--- a/js/src/admin/components/HorizonStatsWidget.tsx
+++ b/js/src/admin/components/HorizonStatsWidget.tsx
@@ -100,13 +100,19 @@ export default class HorizonStatsWidget extends DashboardWidget {
 
   renderStatsSection() {
     const { jobsPerMinute, recentJobs, recentlyFailed, status, processes, queueWithMaxRuntime, queueWithMaxThroughput } = this.data;
+    const redis_stats = this.data.redis_stats ?? {};
 
     return (
       <>
+        {this.renderStatusIndicator(status)}
+        {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.redis-used-memory'), redis_stats.memory_used)}
+        {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.redis-peak-memory'), redis_stats.memory_peak)}
+        {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.redis-max-memory'), redis_stats.max_memory ?? 'auto')}
+        {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.redis-cpu-user'), redis_stats.cpu_user + '%')}
+        {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.redis-cpu-sys'), redis_stats.cpu_sys + '%')}
         {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.jobs-per-minute'), jobsPerMinute)}
         {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.jobs-past-hour'), recentJobs)}
         {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.failed-last-seconds'), recentlyFailed)}
-        {this.renderStatusIndicator(status)}
         {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.total-processes'), processes)}
         {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.max-wait-time'), '-')}
         {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.max-runtime'), queueWithMaxRuntime ?? '-')}

--- a/js/src/admin/components/SettingsPage.js
+++ b/js/src/admin/components/SettingsPage.js
@@ -11,6 +11,53 @@ export default class SettingsPage extends ExtensionPage {
           <LinkButton icon="fas fa-external-link-alt" className="Button" href={horizonUrl} external={true} target="_blank">
             {app.translator.trans('blomstra-horizon.admin.stats.full_dashboard')}
           </LinkButton>
+          <hr />
+          <div className="HorizonSettingsPage-settings">
+            <div className="Form-group">
+              <div className="HorizonSettingsPage-trim">
+                <h3>{app.translator.trans('blomstra-horizon.admin.settings.trim_title')}</h3>
+                <p className="helpText">{app.translator.trans('blomstra-horizon.admin.settings.trim_help')}</p>
+                {this.buildSettingComponent({
+                  setting: 'blomstra-horizon.trim.recent',
+                  type: 'number',
+                  label: app.translator.trans('blomstra-horizon.admin.settings.trim_recent'),
+                  help: app.translator.trans('blomstra-horizon.admin.settings.trim_recent_help'),
+                })}
+                {this.buildSettingComponent({
+                  setting: 'blomstra-horizon.trim.pending',
+                  type: 'number',
+                  label: app.translator.trans('blomstra-horizon.admin.settings.trim_pending'),
+                  help: app.translator.trans('blomstra-horizon.admin.settings.trim_pending_help'),
+                })}
+                {this.buildSettingComponent({
+                  setting: 'blomstra-horizon.trim.completed',
+                  type: 'number',
+                  label: app.translator.trans('blomstra-horizon.admin.settings.trim_completed'),
+                  help: app.translator.trans('blomstra-horizon.admin.settings.trim_completed_help'),
+                })}
+                {this.buildSettingComponent({
+                  setting: 'blomstra-horizon.trim.recent_failed',
+                  type: 'number',
+                  label: app.translator.trans('blomstra-horizon.admin.settings.trim_recent_failed'),
+                  help: app.translator.trans('blomstra-horizon.admin.settings.trim_recent_failed_help'),
+                })}
+                {this.buildSettingComponent({
+                  setting: 'blomstra-horizon.trim.failed',
+                  type: 'number',
+                  label: app.translator.trans('blomstra-horizon.admin.settings.trim_failed'),
+                  help: app.translator.trans('blomstra-horizon.admin.settings.trim_failed_help'),
+                })}
+                {this.buildSettingComponent({
+                  setting: 'blomstra-horizon.trim.monitored',
+                  type: 'number',
+                  label: app.translator.trans('blomstra-horizon.admin.settings.trim_monitored'),
+                  help: app.translator.trans('blomstra-horizon.admin.settings.trim_monitored_help'),
+                })}
+              </div>
+              <br />
+              {this.submitButton()}
+            </div>
+          </div>
         </div>
       </div>
     );

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -1,11 +1,41 @@
 blomstra-horizon:
   admin:
+    settings:
+      trim_title: Trim Settings
+      trim_help: |
+        Here you can configure for how long (in minutes) you desire Horizon to
+        persist the recent and failed jobs. Typically, recent jobs are kept
+        for one hour while all failed jobs are stored for an entire week.
+      trim_recent: Trim Recent Jobs
+      trim_recent_help: |
+        This table is used to display recent jobs in the Horizon dashboard.
+      trim_pending: Trim Pending Jobs
+      trim_pending_help: |
+        This table is used to display pending jobs in the Horizon dashboard.
+      trim_completed: Trim Completed Jobs
+      trim_completed_help: |
+        This table is used to display completed jobs in the Horizon dashboard.
+      trim_recent_failed: Trim Recent Failed Jobs
+      trim_recent_failed_help: |
+        This table is used to display recent failed jobs in the Horizon dashboard.
+      trim_failed: Trim Failed Jobs
+      trim_failed_help: |
+        This table is used to display failed jobs in the Horizon dashboard.
+      trim_monitored: Trim Monitored Jobs
+      trim_monitored_help: |
+        This table is used to display monitored jobs in the Horizon dashboard.
+      
     stats:
       auto_refresh: Auto Refresh
       heading: Queue Overview
       full_dashboard: Horizon Dashboard
       refresh: Refresh
       data:
+        redis-used-memory: Redis Used Memory
+        redis-peak-memory: Redis Peak Memory
+        redis-max-memory: Redis Max Memory
+        redis-cpu-user: Redis CPU User
+        redis-cpu-sys: Redis CPU Sys
         jobs-per-minute: Jobs Per Minute
         jobs-past-hour: Jobs Past Hour
         failed-last-seconds: Failed Jobs Past Few Seconds

--- a/src/Content/AdminContent.php
+++ b/src/Content/AdminContent.php
@@ -34,10 +34,13 @@ class AdminContent
         $document->payload['redisVersion'] = $this->getRedisVersion();
     }
 
+    private function getInfo(): array
+    {
+        return $this->redis->connection()->info();
+    }
+
     protected function getRedisVersion(): string
     {
-        $info = $this->redis->connection()->info();
-
-        return Arr::get($info, 'Server.redis_version', 'unknown');
+        return Arr::get($this->getInfo(), 'Server.redis_version', 'unknown');
     }
 }

--- a/src/Extend/Horizon.php
+++ b/src/Extend/Horizon.php
@@ -24,6 +24,7 @@ class Horizon implements ExtenderInterface
 
     public function extend(Container $container, Extension $extension = null)
     {
+        /** @var Repository $repository */
         $repository = $container->make(Repository::class);
 
         if ($this->config) {

--- a/src/Providers/HorizonServiceProvider.php
+++ b/src/Providers/HorizonServiceProvider.php
@@ -18,6 +18,7 @@ use Blomstra\Redis\Overrides\RedisManager;
 use Flarum\Foundation\Config;
 use Flarum\Foundation\Paths;
 use Flarum\Http\UrlGenerator;
+use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Bus\BatchFactory;
 use Illuminate\Bus\BatchRepository;
 use Illuminate\Bus\DatabaseBatchRepository;
@@ -136,6 +137,9 @@ class HorizonServiceProvider extends Provider
         /** @var UrlGenerator */
         $url = resolve(UrlGenerator::class);
 
+        /** @var SettingsRepositoryInterface $settings */
+        $settings = resolve(SettingsRepositoryInterface::class);
+
         $env = $container->make('env');
 
         $config = include $paths->vendor.'/laravel/horizon/config/horizon.php';
@@ -155,6 +159,15 @@ class HorizonServiceProvider extends Provider
                     'tries'      => 3,
                 ],
             ],
+        ]);
+
+        Arr::set($config, 'trim', [
+            'recent' => $settings->get('blomstra-horizon.trim.recent'),
+            'pending' => $settings->get('blomstra-horizon.trim.pending'),
+            'completed' => $settings->get('blomstra-horizon.trim.completed'),
+            'recent_failed' => $settings->get('blomstra-horizon.trim.recent_failed'),
+            'failed' => $settings->get('blomstra-horizon.trim.failed'),
+            'monitored' => $settings->get('blomstra-horizon.trim.monitored'),
         ]);
 
         /** @var Repository $repository */


### PR DESCRIPTION
Allow setting the job trim values directly from the UI, expose the memory & CPU status to the dashboard for clearer monitoring

![image](https://github.com/blomstra/flarum-ext-horizon/assets/16573496/8847c071-0f44-42f7-b616-945c8bb0d227)

![image](https://github.com/blomstra/flarum-ext-horizon/assets/16573496/5d427e08-b9ac-487e-9bd5-51efbf5e4eda)


These features are kindly sponsored by @glowingblue