### PR TITLE
fix: Max memory always displays auto

### DIFF
--- a/js/src/admin/components/HorizonStatsWidget.tsx
+++ b/js/src/admin/components/HorizonStatsWidget.tsx
@@ -107,7 +107,7 @@ export default class HorizonStatsWidget extends DashboardWidget {
         {this.renderStatusIndicator(status)}
         {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.redis-used-memory'), redis_stats.memory_used)}
         {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.redis-peak-memory'), redis_stats.memory_peak)}
-        {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.redis-max-memory'), redis_stats.max_memory ?? 'auto')}
+        {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.redis-max-memory'), redis_stats.memory_max ?? 'auto')}
         {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.redis-cpu-user'), redis_stats.cpu_user + '%')}
         {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.redis-cpu-sys'), redis_stats.cpu_sys + '%')}
         {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.jobs-per-minute'), jobsPerMinute)}

--- a/src/Api/Stats.php
+++ b/src/Api/Stats.php
@@ -61,7 +61,7 @@ class Stats implements RequestHandlerInterface
             'redis_stats'            => [
                 'memory_used' => Arr::get($this->getInfo(), 'Memory.used_memory_human', 0),
                 'memory_peak' => Arr::get($this->getInfo(), 'Memory.used_memory_peak_human', 0),
-                'memory_max'  => Arr::get($this->getInfo(), 'Memory.maxmemory', 0),
+                'memory_max'  => $this->formatMaxMemory(Arr::get($this->getInfo(), 'Memory.maxmemory_human', 0)),
                 'cpu_user'    => Arr::get($this->getInfo(), 'CPU.used_cpu_user', 0),
                 'cpu_sys'     => Arr::get($this->getInfo(), 'CPU.used_cpu_sys', 0),
             ],
@@ -91,5 +91,14 @@ class Stats implements RequestHandlerInterface
     private function getInfo(): array
     {
         return $this->redis->connection()->info();
+    }
+
+    private function formatMaxMemory($maxMemory): string
+    {
+        if ($maxMemory === '0' || $maxMemory === '0B') {
+            return 'auto';
+        }
+
+        return $maxMemory;
     }
 }

--- a/src/Api/Stats.php
+++ b/src/Api/Stats.php
@@ -93,7 +93,7 @@ class Stats implements RequestHandlerInterface
         return $this->redis->connection()->info();
     }
 
-    private function formatMaxMemory($maxMemory): string
+    private function formatMaxMemory(string $maxMemory): string
     {
         if ($maxMemory === '0' || $maxMemory === '0B') {
             return 'auto';


### PR DESCRIPTION
When setting the `maxmemory` limit on a Redis instance, the stats continue to display `auto`. This PR fixes that.


Before:
![image](https://github.com/blomstra/flarum-ext-horizon/assets/16573496/8096dccb-e7a5-46ae-bc26-ec944335d9e8)


After:
![image](https://github.com/blomstra/flarum-ext-horizon/assets/16573496/9cfcdcc1-4485-4c26-b6a1-bc283d5caa02)
