### PR TITLE
feat: display memory eviction policy in redis admin widget

### DIFF
--- a/js/src/admin/components/HorizonStatsWidget.tsx
+++ b/js/src/admin/components/HorizonStatsWidget.tsx
@@ -3,11 +3,12 @@ import app from 'flarum/admin/app';
 import DashboardWidget, { IDashboardWidgetAttrs } from 'flarum/admin/components/DashboardWidget';
 import LoadingIndicator from 'flarum/common/components/LoadingIndicator';
 import Button from 'flarum/common/components/Button';
-import type Mithril from 'mithril';
+import Mithril from 'mithril';
 import LinkButton from 'flarum/common/components/LinkButton';
 import Tooltip from 'flarum/common/components/Tooltip';
 import Switch from 'flarum/common/components/Switch';
 import icon from 'flarum/common/helpers/icon';
+import ItemList from 'flarum/common/utils/ItemList';
 
 export default class HorizonStatsWidget extends DashboardWidget {
   loading = true;
@@ -107,8 +108,13 @@ export default class HorizonStatsWidget extends DashboardWidget {
         {this.renderStatusIndicator(status)}
         {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.redis-used-memory'), redis_stats.memory_used)}
         {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.redis-peak-memory'), redis_stats.memory_peak)}
-        {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.redis-max-memory'), redis_stats.max_memory ?? 'auto')}
-        {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.redis-memory-policy'), redis_stats.memory_max_policy)}
+        {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.redis-max-memory'), redis_stats.memory_max ?? 'auto')}
+        {this.renderStat(
+          app.translator.trans('blomstra-horizon.admin.stats.data.redis-memory-policy'),
+          redis_stats.memory_max_policy,
+          app.translator.trans('blomstra-horizon.admin.stats.data.redis-memory-policy-tooltip'),
+          'https://redis.io/docs/latest/develop/reference/eviction/'
+        )}
         {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.redis-cpu-user'), redis_stats.cpu_user + '%')}
         {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.redis-cpu-sys'), redis_stats.cpu_sys + '%')}
         {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.jobs-per-minute'), jobsPerMinute)}
@@ -122,13 +128,53 @@ export default class HorizonStatsWidget extends DashboardWidget {
     );
   }
 
-  renderStat(label: NestedStringArray, value: string) {
-    return (
-      <div className="HorizonStatsWidget-stat">
-        <small>{label}</small>
-        <p>{value || !this.loading ? value : <LoadingIndicator size="small" display="inline" />}</p>
-      </div>
-    );
+  renderStat(
+    label: NestedStringArray | string,
+    value: string,
+    infoLabel: NestedStringArray | string | undefined = undefined,
+    infoUrl: string | undefined = undefined
+  ) {
+    return <div className="HorizonStatsWidget-stat">{this.statItems(label, value, infoLabel, infoUrl).toArray()}</div>;
+  }
+
+  statItems(
+    label: NestedStringArray | string,
+    value: string,
+    infoLabel: NestedStringArray | string | undefined,
+    infoUrl: string | undefined
+  ): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
+
+    items.add('label', <small>{this.labelItems(label, infoLabel, infoUrl).toArray()}</small>, 100);
+
+    items.add('value', <p>{value || !this.loading ? value : <LoadingIndicator size="small" display="inline" />}</p>, 80);
+
+    return items;
+  }
+
+  labelItems(
+    label: NestedStringArray | string,
+    infoLabel: NestedStringArray | string | undefined,
+    infoUrl: string | undefined
+  ): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
+
+    items.add('label', <span>{label}</span>, 100);
+
+    if (infoLabel && infoUrl) {
+      items.add(
+        'info',
+        <Tooltip text={infoLabel}>
+          <span>
+            {' '}
+            <LinkButton href={infoUrl} external={true} target="_blank" icon="fas fa-info-circle" />
+          </span>
+        </Tooltip>,
+        90
+      );
+    }
+
+    return items;
   }
 
   renderStatusIndicator(status: string | null) {

--- a/js/src/admin/components/HorizonStatsWidget.tsx
+++ b/js/src/admin/components/HorizonStatsWidget.tsx
@@ -107,7 +107,8 @@ export default class HorizonStatsWidget extends DashboardWidget {
         {this.renderStatusIndicator(status)}
         {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.redis-used-memory'), redis_stats.memory_used)}
         {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.redis-peak-memory'), redis_stats.memory_peak)}
-        {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.redis-max-memory'), redis_stats.memory_max ?? 'auto')}
+        {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.redis-max-memory'), redis_stats.max_memory ?? 'auto')}
+        {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.redis-memory-policy'), redis_stats.memory_max_policy)}
         {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.redis-cpu-user'), redis_stats.cpu_user + '%')}
         {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.redis-cpu-sys'), redis_stats.cpu_sys + '%')}
         {this.renderStat(app.translator.trans('blomstra-horizon.admin.stats.data.jobs-per-minute'), jobsPerMinute)}

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -34,6 +34,7 @@ blomstra-horizon:
         redis-used-memory: Redis Used Memory
         redis-peak-memory: Redis Peak Memory
         redis-max-memory: Redis Max Memory
+        redis-memory-policy: Redis Memory Policy
         redis-cpu-user: Redis CPU User
         redis-cpu-sys: Redis CPU Sys
         jobs-per-minute: Jobs Per Minute

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -35,6 +35,10 @@ blomstra-horizon:
         redis-peak-memory: Redis Peak Memory
         redis-max-memory: Redis Max Memory
         redis-memory-policy: Redis Memory Policy
+        redis-memory-policy-tooltip: |
+          The memory policy is the way Redis will select what to remove when
+          the maxmemory limit is reached. The default is `noeviction`: New values 
+          aren’t saved when memory limit is reached. Click to view documentation.
         redis-cpu-user: Redis CPU User
         redis-cpu-sys: Redis CPU Sys
         jobs-per-minute: Jobs Per Minute

--- a/src/Api/Stats.php
+++ b/src/Api/Stats.php
@@ -62,6 +62,7 @@ class Stats implements RequestHandlerInterface
                 'memory_used' => Arr::get($this->getInfo(), 'Memory.used_memory_human', 0),
                 'memory_peak' => Arr::get($this->getInfo(), 'Memory.used_memory_peak_human', 0),
                 'memory_max'  => $this->formatMaxMemory(Arr::get($this->getInfo(), 'Memory.maxmemory_human', 0)),
+                'memory_max_policy' => Arr::get($this->getInfo(), 'Memory.maxmemory_policy', ''),
                 'cpu_user'    => Arr::get($this->getInfo(), 'CPU.used_cpu_user', 0),
                 'cpu_sys'     => Arr::get($this->getInfo(), 'CPU.used_cpu_sys', 0),
             ],


### PR DESCRIPTION
For example:

![image](https://github.com/blomstra/flarum-ext-horizon/assets/16573496/bba3c729-714a-4c6c-a948-121fc625d8e4)

or

![image](https://github.com/blomstra/flarum-ext-horizon/assets/16573496/24d2dc34-127d-4e96-a98b-daa5ccf4d4aa)

etc

